### PR TITLE
add GitHub Actions workflow 'test.yml'

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,12 @@
+name: 'test'
+on: [ push, pull_request ]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v1
+    - run: docker run --rm -tv $(pwd):/src -w /src ghdl/vunit:llvm python3 run.py
+#    - uses: actions/upload-artifact@master
+#      with:
+#        name: <name of the resulting zipfile
+#        path: <directory to zip and upload>


### PR DESCRIPTION
A GitHub Actions worklow is added (`test.yml`). This is equivalent to `.travis.yml`, but image `ghdl/vunit:llvm` is used. E.g.: https://github.com/1138-4EB/Compliance-Tests/commit/2fc5f72a177a2fe5e575a3d6d2e4aefa463303ff/checks?check_suite_id=260291491

The step that is commented, allows to upload artifacts such as logs/reports to each job/run. However, I don't know what might we want to upload ATM.